### PR TITLE
Fix the error: "A task is already running"

### DIFF
--- a/root/usr/share/AdGuardHome/update_core.sh
+++ b/root/usr/share/AdGuardHome/update_core.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 binpath=$(uci get AdGuardHome.AdGuardHome.binpath)
 if [ -z "$binpath" ]; then


### PR DESCRIPTION
The new version of openwrt source code prompts when checking for updates.
`A task is already running.`

So I connect to ssh and want to use `update_core.sh` from the command line using the absolute path method
```
root@OpenWrt:/www# /usr/share/AdGuardHome/update_core.sh

A task is already running.
```
But when I go to `/usr/share/AdGuardHome` directory, I can update it normally by relative path.
```
root@OpenWrt:/www# cd /usr/share/AdGuardHome
root@OpenWrt:/usr/share/AdGuardHome# ./update_core.sh
/usr/bin/curl
Check for update...

Local version: v0.107.21, cloud version: v0.107.21.
You're already using the latest version.
```
I looked at the other scripts in the `/usr/share/AdGuardHome` directory and found that they all use `#!/bin/sh`, so I tried `update_core.sh` with `#!/bin/sh` in `update_core.sh`, I got normal output and the function works fine