### PR TITLE
Fix compatibility issues and download speed problems

### DIFF
--- a/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
+++ b/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
@@ -1,17 +1,15 @@
-#提交就可以直接用的配置模板文件。 user: root/password: admin
-#a template config can be use with a apply. user: root/password: admin
+#提交就可以直接用的配置模板文件。 user: root/password: password
+#a template config can be use with a apply. user: root/password: password
 
 http:
   pprof:
     port: 6060
     enabled: false
   address: 0.0.0.0:3000
-  #上方的address: 0.0.0.0可根据自己的情况修改，比如路由IP或者保留。
-  #You can modify this "address: 0.0.0.0" above by yourself,  set as the routing IP according to your requirements, or keep.
   session_ttl: 720h
 users:
   - name: root
-    password: $2y$10$ML7v5WXsM1xN12YpR15f4uSGGAzk.QXhwu99lczQ8NgrPcTYRY9Ei
+    password: $2a$10$MsY.D1AD7GCfB1H0A/bv9.wt7ppWR/BN9if3pd2JrTlKibxFVQYBu
 auth_attempts: 5
 block_auth_min: 15
 http_proxy: ""
@@ -28,12 +26,13 @@ dns:
   ratelimit_whitelist: []
   refuse_any: true
   upstream_dns:
-    - 1.1.1.1
-    - 114.114.114.114
+    - https://dns10.quad9.net/dns-query
   upstream_dns_file: ""
   bootstrap_dns:
-    - 1.1.1.1
-    - 114.114.114.114
+    - 9.9.9.10
+    - 149.112.112.10
+    - 2620:fe::10
+    - 2620:fe::fe:10
   fallback_dns: []
   all_servers: false
   fastest_addr: false

--- a/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
+++ b/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
@@ -114,4 +114,4 @@ dhcp:
 clients: []
 log_file: ""
 verbose: false
-schema_version: 6
+schema_version: 27

--- a/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
+++ b/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
@@ -1,117 +1,178 @@
 #提交就可以直接用的配置模板文件。 user: root/password: admin
 #a template config can be use with a apply. user: root/password: admin
 
-bind_host: 0.0.0.0
-#上方的bind_host: 0.0.0.0可根据自己的情况修改，比如路由IP或者保留。
-#You can modify this "bind_host: 0.0.0.0" above by yourself,  set as the routing IP according to your requirements, or keep.
-
-bind_port: 3000
+http:
+  pprof:
+    port: 6060
+    enabled: false
+  address: 0.0.0.0:3000
+  #上方的address: 0.0.0.0可根据自己的情况修改，比如路由IP或者保留。
+  #You can modify this "address: 0.0.0.0" above by yourself,  set as the routing IP according to your requirements, or keep.
+  session_ttl: 720h
 users:
-- name: root
-  password: $2y$10$ML7v5WXsM1xN12YpR15f4uSGGAzk.QXhwu99lczQ8NgrPcTYRY9Ei
+  - name: root
+    password: $2y$10$ML7v5WXsM1xN12YpR15f4uSGGAzk.QXhwu99lczQ8NgrPcTYRY9Ei
+auth_attempts: 5
+block_auth_min: 15
+http_proxy: ""
 language: ""
-rlimit_nofile: 0
+theme: auto
 dns:
-  bind_host: 0.0.0.0
-  port: 5553
-  statistics_interval: 1
-  protection_enabled: true
-  filtering_enabled: true
-  filters_update_interval: 24
-  blocking_mode: nxdomain
-  blocked_response_ttl: 10
-  querylog_enabled: false
-  querylog_interval: 1
-  ratelimit: 0
+  bind_hosts:
+    - 0.0.0.0
+  port: 53
+  anonymize_client_ip: false
+  ratelimit: 20
+  ratelimit_subnet_len_ipv4: 24
+  ratelimit_subnet_len_ipv6: 56
   ratelimit_whitelist: []
-  refuse_any: false
-  bootstrap_dns:
-    - 1.1.1.1
-    - 114.114.114.114
-#bootstrap_dns
-  all_servers: false
-  allowed_clients: []
-  disallowed_clients: []
-  blocked_hosts: []
-  parental_block_host: ""
-  safebrowsing_block_host: ""
-  blocked_services: []
-  cache_size: 4194304
-  parental_sensitivity: 13
-  parental_enabled: false
-  safesearch_enabled: false
-  safebrowsing_enabled: false
-  safebrowsing_cache_size: 1048576
-  safesearch_cache_size: 1048576
-  parental_cache_size: 1048576
-  cache_time: 30
-  rewrites: []
+  refuse_any: true
   upstream_dns:
     - 1.1.1.1
     - 114.114.114.114
-#upstream_dns
+  upstream_dns_file: ""
+  bootstrap_dns:
+    - 1.1.1.1
+    - 114.114.114.114
+  fallback_dns: []
+  all_servers: false
+  fastest_addr: false
+  fastest_timeout: 1s
+  allowed_clients: []
+  disallowed_clients: []
+  blocked_hosts:
+    - version.bind
+    - id.server
+    - hostname.bind
+  trusted_proxies:
+    - 127.0.0.0/8
+    - ::1/128
+  cache_size: 4194304
+  cache_ttl_min: 0
+  cache_ttl_max: 0
+  cache_optimistic: false
+  bogus_nxdomain: []
+  aaaa_disabled: false
+  enable_dnssec: false
+  edns_client_subnet:
+    custom_ip: ""
+    enabled: false
+    use_custom: false
+  max_goroutines: 300
+  handle_ddr: true
+  ipset: []
+  ipset_file: ""
+  bootstrap_prefer_ipv6: false
+  upstream_timeout: 10s
+  private_networks: []
+  use_private_ptr_resolvers: true
+  local_ptr_upstreams: []
+  use_dns64: false
+  dns64_prefixes: []
+  serve_http3: false
+  use_http3_upstreams: false
+  serve_plain_dns: true
 tls:
   enabled: false
   server_name: ""
   force_https: false
   port_https: 443
   port_dns_over_tls: 853
+  port_dns_over_quic: 853
+  port_dnscrypt: 0
+  dnscrypt_config_file: ""
+  allow_unencrypted_doh: false
   certificate_chain: ""
   private_key: ""
   certificate_path: ""
   private_key_path: ""
+  strict_sni_check: false
+querylog:
+  ignored: []
+  interval: 2160h
+  size_memory: 1000
+  enabled: true
+  file_enabled: true
+statistics:
+  ignored: []
+  interval: 24h
+  enabled: true
 filters:
-- enabled: true
-  url: https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
-  name: AdGuard Simplified Domain Names filter
-  id: 1
-- enabled: true
-  url: https://adaway.org/hosts.txt
-  name: AdAway
-  id: 2
-- enabled: false
-  url: https://hosts-file.net/ad_servers.txt
-  name: hpHosts - Ad and Tracking servers only
-  id: 3
-- enabled: false
-  url: https://www.malwaredomainlist.com/hostslist/hosts.txt
-  name: MalwareDomainList.com Hosts List
-  id: 4
-- enabled: false
-  url: https://raw.githubusercontent.com/vokins/yhosts/master/data/tvbox.txt
-  name: tvbox
-  id: 1575018007
-- enabled: false
-  url: https://cdn.jsdelivr.net/gh/neoFelhz/neohosts@gh-pages/full/hosts.txt
-  name: neoHosts full
-  id: 1575618240
-- enabled: false
-  url: https://cdn.jsdelivr.net/gh/neoFelhz/neohosts@gh-pages/basic/hosts.txt
-  name: neoHosts basic
-  id: 1575618241
-- enabled: false
-  url: http://sbc.io/hosts/hosts
-  name: StevenBlack host basic
-  id: 1575618242
-- enabled: false
-  url: http://sbc.io/hosts/alternates/fakenews-gambling-porn-social/hosts
-  name: StevenBlack host+fakenews + gambling + porn + social
-  id: 1575618243
-- enabled: false
-  url: https://cdn.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-easylist.txt
-  name: anti-AD(Adblock+neohosts+yhosts+cjxlist+adhlist)
-  id: 1577113202
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+    name: AdGuard DNS filter
+    id: 1
+  - enabled: false
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
+    name: AdAway Default Blocklist
+    id: 2
+whitelist_filters: []
 user_rules: []
 dhcp:
   enabled: false
   interface_name: ""
-  gateway_ip: ""
-  subnet_mask: ""
-  range_start: ""
-  range_end: ""
-  lease_duration: 86400
-  icmp_timeout_msec: 1000
-clients: []
-log_file: ""
-verbose: false
+  local_domain_name: lan
+  dhcpv4:
+    gateway_ip: ""
+    subnet_mask: ""
+    range_start: ""
+    range_end: ""
+    lease_duration: 86400
+    icmp_timeout_msec: 1000
+    options: []
+  dhcpv6:
+    range_start: ""
+    lease_duration: 86400
+    ra_slaac_only: false
+    ra_allow_slaac: false
+filtering:
+  blocking_ipv4: ""
+  blocking_ipv6: ""
+  blocked_services:
+    schedule:
+      time_zone: Local
+    ids: []
+  protection_disabled_until: null
+  safe_search:
+    enabled: false
+    bing: true
+    duckduckgo: true
+    google: true
+    pixabay: true
+    yandex: true
+    youtube: true
+  blocking_mode: default
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  rewrites: []
+  safebrowsing_cache_size: 1048576
+  safesearch_cache_size: 1048576
+  parental_cache_size: 1048576
+  cache_time: 30
+  filters_update_interval: 24
+  blocked_response_ttl: 10
+  filtering_enabled: true
+  parental_enabled: false
+  safebrowsing_enabled: false
+  protection_enabled: true
+clients:
+  runtime_sources:
+    whois: true
+    arp: true
+    rdns: true
+    dhcp: true
+    hosts: true
+  persistent: []
+log:
+  file: ""
+  max_backups: 0
+  max_size: 100
+  max_age: 3
+  compress: false
+  local_time: false
+  verbose: false
+os:
+  group: ""
+  user: ""
+  rlimit_nofile: 0
 schema_version: 27

--- a/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
+++ b/root/usr/share/AdGuardHome/AdGuardHome_template.yaml
@@ -114,4 +114,4 @@ dhcp:
 clients: []
 log_file: ""
 verbose: false
-schema_version: 5
+schema_version: 6

--- a/root/usr/share/AdGuardHome/links.txt
+++ b/root/usr/share/AdGuardHome/links.txt
@@ -1,3 +1,3 @@
-https://static.adguard.com/adguardhome/release/AdGuardHome_linux_${Arch}.tar.gz
+#https://static.adguard.com/adguardhome/release/AdGuardHome_linux_${Arch}.tar.gz
 #https://static.adguard.com/adguardhome/beta/AdGuardHome_linux_${Arch}.tar.gz
-https://github.com/AdguardTeam/AdGuardHome/releases/download/${latest_ver}/AdGuardHome_linux_${Arch}.tar.gz
+https://ghproxy.com/https://github.com/AdguardTeam/AdGuardHome/releases/download/${latest_ver}/AdGuardHome_linux_${Arch}.tar.gz

--- a/root/usr/share/AdGuardHome/links_backup.txt
+++ b/root/usr/share/AdGuardHome/links_backup.txt
@@ -1,3 +1,3 @@
-https://static.adguard.com/adguardhome/release/AdGuardHome_linux_${Arch}.tar.gz
+#https://static.adguard.com/adguardhome/release/AdGuardHome_linux_${Arch}.tar.gz
 #https://static.adguard.com/adguardhome/beta/AdGuardHome_linux_${Arch}.tar.gz
-https://github.com/AdguardTeam/AdGuardHome/releases/download/${latest_ver}/AdGuardHome_linux_${Arch}.tar.gz
+https://ghproxy.com/https://github.com/AdguardTeam/AdGuardHome/releases/download/${latest_ver}/AdGuardHome_linux_${Arch}.tar.gz


### PR DESCRIPTION
1、修复第一次下载完最新核心执行文件后，不兼容旧版本yaml，导致日志报：
```
2023/08/14 19:51:13.781764 [info] Upgrade yaml: 5 to 6
2023/08/14 19:51:13.778894 [info] AdGuard Home, version v0.107.36
2023/08/14 19:51:08.739051 [fatal] unexpected type of clients: []interface {}
2023/08/14 19:51:08.738965 [info] Upgrade yaml: 5 to 6
2023/08/14 19:51:08.734928 [info] AdGuard Home, version v0.107.36 
```
从而无法启动程序
2、加速核心文件下载速度