### PR TITLE
Use uci to manage firewall

### DIFF
--- a/root/etc/init.d/AdGuardHome
+++ b/root/etc/init.d/AdGuardHome
@@ -63,16 +63,12 @@ stop_forward_dnsmasq()
 
 set_iptable()
 {
-	section=$(uci add firewall redirect)
-	if [ -z "$section" ]; then
-		echo "failed to add redirect rule."
-		exit 1
-	fi
-	uci set firewall.$section.target="DNAT"
-	uci set firewall.$section.name="AdGuard Home"
-	uci set firewall.$section.src="lan"
-	uci set firewall.$section.src_dport="53"
-	uci set firewall.$section.dest_port="$AdGuardHome_PORT"
+	uci set firewall.adguardhome_redirect="redirect"
+	uci set firewall.adguardhome_redirect.target="DNAT"
+	uci set firewall.adguardhome_redirect.name="AdGuard Home"
+	uci set firewall.adguardhome_redirect.src="lan"
+	uci set firewall.adguardhome_redirect.src_dport="53"
+	uci set firewall.adguardhome_redirect.dest_port="$AdGuardHome_PORT"
 	uci commit firewall
 	/etc/init.d/firewall reload
 	echo "firewall rules updated."
@@ -80,17 +76,14 @@ set_iptable()
 
 clear_iptable()
 {
-	redirects=$(uci show firewall | grep "AdGuard Home" | awk -F".name" '{print $1}')
+	redirects=$(uci show firewall | grep "firewall.adguardhome_redirect")
 	if [ -z "$redirects" ]; then
 		echo "no redirect rules found."
 	else
-		for redirect in $redirects; do
-			uci delete $redirect
-			echo "deleted redirect rule: $redirect"
-		done
+		uci delete firewall.adguardhome_redirect
 		uci commit firewall
 		/etc/init.d/firewall reload
-		echo "firewall rules updated."
+		echo "deleted redirect rule: firewall.adguardhome_redirect"
 	fi
 }
 

--- a/root/etc/init.d/AdGuardHome
+++ b/root/etc/init.d/AdGuardHome
@@ -63,67 +63,35 @@ stop_forward_dnsmasq()
 
 set_iptable()
 {
-	local ipv6_server=$1
-	local tcp_server=$2
-	uci -q batch <<-EOF >/dev/null 2>&1
-  delete firewall.AdGuardHome
-	set firewall.AdGuardHome=include
-	set firewall.AdGuardHome.type=script
-	set firewall.AdGuardHome.path=/usr/share/AdGuardHome/firewall.start
-	set firewall.AdGuardHome.reload=1
-	commit firewall
-EOF
-
-	IPS="`ifconfig | grep "inet addr" | grep -v ":127" | grep "Bcast" | awk '{print $2}' | awk -F : '{print $2}'`"
-	for IP in $IPS
-	do
-		if [ "$tcp_server" == "1" ]; then
-			iptables -t nat -A PREROUTING -p tcp -d $IP --dport 53 -j REDIRECT --to-ports $AdGuardHome_PORT >/dev/null 2>&1
-		fi
-		iptables -t nat -A PREROUTING -p udp -d $IP --dport 53 -j REDIRECT --to-ports $AdGuardHome_PORT >/dev/null 2>&1
-	done
-
-	if [ "$ipv6_server" == 0 ]; then
-		return
+	section=$(uci add firewall redirect)
+	if [ -z "$section" ]; then
+		echo "failed to add redirect rule."
+		exit 1
 	fi
-
-	IPS="`ifconfig | grep "inet6 addr" | grep -v " fe80::" | grep -v " ::1" | grep "Global" | awk '{print $3}'`"
-	for IP in $IPS
-	do
-		if [ "$tcp_server" == "1" ]; then
-			ip6tables -t nat -A PREROUTING -p tcp -d $IP --dport 53 -j REDIRECT --to-ports $AdGuardHome_PORT >/dev/null 2>&1
-		fi
-		ip6tables -t nat -A PREROUTING -p udp -d $IP --dport 53 -j REDIRECT --to-ports $AdGuardHome_PORT >/dev/null 2>&1
-	done
-
+	uci set firewall.$section.target="DNAT"
+	uci set firewall.$section.name="AdGuard Home"
+	uci set firewall.$section.src="lan"
+	uci set firewall.$section.src_dport="53"
+	uci set firewall.$section.dest_port="$AdGuardHome_PORT"
+	uci commit firewall
+	/etc/init.d/firewall reload
+	echo "firewall rules updated."
 }
 
 clear_iptable()
 {
-	uci -q batch <<-EOF >/dev/null 2>&1
-  delete firewall.AdGuardHome
-	commit firewall
-EOF
-	local OLD_PORT="$1"
-	local ipv6_server=$2
-	IPS="`ifconfig | grep "inet addr" | grep -v ":127" | grep "Bcast" | awk '{print $2}' | awk -F : '{print $2}'`"
-	for IP in $IPS
-	do
-		iptables -t nat -D PREROUTING -p udp -d $IP --dport 53 -j REDIRECT --to-ports $OLD_PORT >/dev/null 2>&1
-		iptables -t nat -D PREROUTING -p tcp -d $IP --dport 53 -j REDIRECT --to-ports $OLD_PORT >/dev/null 2>&1
-	done
-
-	if [ "$ipv6_server" == 0 ]; then
-		return
+	redirects=$(uci show firewall | grep "AdGuard Home" | awk -F".name" '{print $1}')
+	if [ -z "$redirects" ]; then
+		echo "no redirect rules found."
+	else
+		for redirect in $redirects; do
+			uci delete $redirect
+			echo "deleted redirect rule: $redirect"
+		done
+		uci commit firewall
+		/etc/init.d/firewall reload
+		echo "firewall rules updated."
 	fi
-	echo "warn ip6tables nat mod is needed"
-	IPS="`ifconfig | grep "inet6 addr" | grep -v " fe80::" | grep -v " ::1" | grep "Global" | awk '{print $3}'`"
-	for IP in $IPS
-	do
-		ip6tables -t nat -D PREROUTING -p udp -d $IP --dport 53 -j REDIRECT --to-ports $OLD_PORT >/dev/null 2>&1
-		ip6tables -t nat -D PREROUTING -p tcp -d $IP --dport 53 -j REDIRECT --to-ports $OLD_PORT >/dev/null 2>&1
-	done
-
 }
 
 service_triggers() {
@@ -244,7 +212,7 @@ _do_redirect()
 	if [ "$old_redirect" != "$redirect" ] || [ "$old_port" != "$AdGuardHome_PORT" ] || [ "$old_enabled" = "1" -a "$enabled" = "0" ]; then
 		if [ "$old_redirect" != "none" ]; then
 			if [  "$old_redirect" == "redirect" -a "$old_port" != "0" ]; then
-				clear_iptable "$old_port" "$ipv6_server"
+				clear_iptable
 			elif [ "$old_redirect" == "dnsmasq-upstream" ]; then
 				stop_forward_dnsmasq "$old_port"
 			elif [ "$old_redirect" == "exchange" ]; then
@@ -253,7 +221,7 @@ _do_redirect()
 		fi
 	elif [ "$old_enabled" = "1" -a "$enabled" = "1" ]; then
 		if [  "$old_redirect" == "redirect" -a "$old_port" != "0" ]; then
-			clear_iptable "$old_port" "$ipv6_server"
+			clear_iptable
 		fi
 	fi
 	uci delete AdGuardHome.@AdGuardHome[0].old_redirect 2>/dev/null
@@ -268,7 +236,7 @@ _do_redirect()
 		return 1
 	fi
 	if [ "$redirect" = "redirect" ]; then
-		set_iptable $ipv6_server $tcp_server
+		set_iptable
 	elif [ "$redirect" = "dnsmasq-upstream" ]; then
 		set_forward_dnsmasq "$AdGuardHome_PORT"
 	elif [ "$redirect" == "exchange" -a "$(uci get dhcp.@dnsmasq[0].port 2>/dev/null)" == "53" ]; then

--- a/root/usr/share/AdGuardHome/firewall.start
+++ b/root/usr/share/AdGuardHome/firewall.start
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-AdGuardHome_enable=$(uci get AdGuardHome.AdGuardHome.enabled)
-redirect=$(uci get AdGuardHome.AdGuardHome.redirect)
-
-if [ $AdGuardHome_enable -eq 1 -a "$redirect" == "redirect" ]; then
-	/etc/init.d/AdGuardHome do_redirect 1
-fi

--- a/root/usr/share/rpcd/acl.d/luci-app-adguardhome.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-adguardhome.json
@@ -5,7 +5,6 @@
             "file": {
                 "/usr/share/AdGuardHome/addhost.sh": [ "exec" ],
                 "/usr/share/AdGuardHome/AdGuardHome_template.yaml": [ "read" ],
-                "/usr/share/AdGuardHome/firewall.start": [ "read" ],
                 "/usr/share/AdGuardHome/getsyslog.sh": [ "exec" ],
                 "/usr/share/AdGuardHome/gfw2adg.sh": [ "exec" ],
                 "/usr/share/AdGuardHome/gfwipset2adg.sh": [ "exec" ],
@@ -23,7 +22,6 @@
 		"write": {
             "file": {
                 "/usr/share/AdGuardHome/AdGuardHome_template.yaml": [ "write" ],
-                "/usr/share/AdGuardHome/firewall.start": [ "write" ],
                 "/usr/share/AdGuardHome/links.txt": [ "write" ]
             },
 			"uci": [ "AdGuardHome", "adguardhome" ]


### PR DESCRIPTION
OpenWrt is switching to fw4 since version 22.03. Using commands like `iptables` and `ip6tables` will generate warning messages in the system. 
<img width="963" alt="截屏2024-03-25 12 02 38" src="https://github.com/kongfl888/luci-app-adguardhome/assets/16272760/0880de8e-bcab-4a34-9e9f-6fe6f489c3e4">
Maintaining firewall settings with "uci set firewall" can be compatible with both new and old versions of OpenWrt.
